### PR TITLE
fix: Add missing key-value pair to restaurant json

### DIFF
--- a/.tmp/localDiskDb.db
+++ b/.tmp/localDiskDb.db
@@ -391,6 +391,7 @@
       {
         "name": "Casa Enrique",
         "neighborhood": "Queens",
+	"photograph": "10",
         "address": "5-48 49th Ave, Queens, NY 11101",
         "latlng": {
           "lat": 40.743394,


### PR DESCRIPTION
The restaurant JSON in .tmp/localDiskDb.db is missing a key-value pair.  This results in a broken image appearing when function _createRestaurantHTML_ in main.js calls function _DBHelper.imageUrlForRestaurant(restaurant)_: the src attribute for the img tag gets filled with '/img/undefined.jpg'.