### PR TITLE
A fix of restaurants json

### DIFF
--- a/.tmp/localDiskDb.db
+++ b/.tmp/localDiskDb.db
@@ -391,6 +391,7 @@
       {
         "name": "Casa Enrique",
         "neighborhood": "Queens",
+        "photograph": "10",
         "address": "5-48 49th Ave, Queens, NY 11101",
         "latlng": {
           "lat": 40.743394,


### PR DESCRIPTION
Restaurant 'Casa Enrique'  had no `photograph` property, as a result, the front-end was receiving `undefined` and wan't able to show the image of the restaurant.